### PR TITLE
Adding Windows support for siteleaf push theme

### DIFF
--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -113,7 +113,11 @@ def put_theme_assets(site_id)
   else
     puts "=> Could not upload assets.\n"
   end
-  FileUtils.rm(theme) if File.exist?(theme)
+  if is_windows = (RbConfig::CONFIG[ 'host_os' ] =~ /mswin|mingw|cygwin/)
+    FileUtils.rm_rf(theme) if File.exists?(theme)
+  else
+    FileUtils.rm(theme) if File.exist?(theme)
+  end
 end
 
 case ARGV[0]


### PR DESCRIPTION
`FileUtils.rm` doesn't work on Windows, because you need to use `rm -rf` on the command line to delete files.

So I added in an `if is_windows` and added `FileUtils.rm_rf` to make the gem compatible with Windows.
