### PR TITLE
Error when accessing subpage

### DIFF
--- a/lib/siteleaf/page.rb
+++ b/lib/siteleaf/page.rb
@@ -23,8 +23,8 @@ module Siteleaf
     end
     
     def pages
-      result = Client.get "pages/#{self.id}/pages"
-      result.map { |r| self.new(r) } if result
+      result = Client.get "pages/#{self.id}?include=pages"
+      result["pages"].map { |r| self.new(r) } if result
     end
     
     def page

--- a/lib/siteleaf/page.rb
+++ b/lib/siteleaf/page.rb
@@ -24,7 +24,7 @@ module Siteleaf
     
     def pages
       result = Client.get "pages/#{self.id}?include=pages"
-      result["pages"].map { |r| self.new(r) } if result
+      result["pages"].map { |r| Page.new(r) } if result
     end
     
     def page


### PR DESCRIPTION
(oops, posted this before I had finished writing)

In the gem, I am trying to get a list of a page's subpages, but receive an error:

```ruby
page = Siteleaf::Page.find(page_id)
page.pages
```
returns
```ruby
NoMethodError: undefined method `map' for #<HTTParty::Response:0x007fbef8395eb8>
from /Users/ezra/.rbenv/versions/2.1.1/gemsets/project/gems/httparty-0.11.0/lib/httparty/response.rb:61:in `method_missing'
```

This happens whether or not the page has any subpages. Is there any way to get a page's children? I've had no issue with posts at all.