### PR TITLE
Needed new Commands for no prompts and added some that I thought might be useful

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ To replace the entire theme by the one in the current local directory. Not like 
     siteleaf replace theme -n  
 
 
+**Add A single or multiple file to theme:**
+
+Uses for this are endless if we use it just for config.ru file we can create posts and pages just by this command dynamically.
+
+Adding Files to theme it will only replace if the name matches otherwise it'll just add that file.
+
+        siteleaf add theme  
+
+Adding Files to theme it will only replace if the name matches otherwise it'll just add that file without any prompts of deletion i.e. no [y/n] it's a direct y.
+
+        siteleaf add theme  -n
+
+
 Using this gem in your application
 ----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Your site should now be accessible at `http://yoursite.dev`.
 **If you don't want to install Pow, local sites can also be manually run:**
 
     siteleaf server
-  
+
 In this case, your local site can be accessed at `http://localhost:9292`.
 
 **Lastly...**
@@ -62,15 +62,38 @@ To download your theme (or the default theme for new sites) from Siteleaf, run t
 To upload your theme to Siteleaf, run the following command:
 
     siteleaf push theme
-    
+
 To switch Siteleaf users or re-authenticate:
 
     siteleaf auth
 
 
+**Added New Commands:**
+
+To Push the entire theme without any prompts of deletion i.e. no [y/n] from user it's a direct y .
+
+    siteleaf push theme -n  
+
+To delete the entire theme.
+
+    siteleaf delete theme
+
+To delete the entire theme without any prompts of deletion i.e. no [y/n] it's a direct y.
+
+    siteleaf delete theme -n
+
+To replace the entire theme by the one in the current local directory. Not like push where old revision is checked instead an entire cleanout and the new theme is loaded.
+
+    siteleaf replace theme
+
+To replace the entire theme by the one in the current local directory. Not like push where old revision is checked instead an entire cleanout and the new theme is loaded without any prompts of deletion i.e. no [y/n] it's a direct y.
+
+    siteleaf replace theme -n  
+
+
 Using this gem in your application
 ----------------------------------
-    
+
 To use this gem in your application, add the following to your Gemfile:
 
     gem 'siteleaf', :git => 'git://github.com/siteleaf/siteleaf-gem.git'
@@ -141,8 +164,8 @@ post.save
 
 # upload asset to post (use site_id, page_id, or theme_id to upload to Site, Page, or Theme instead)
 asset = Siteleaf::Asset.create({
-  :post_id  => post.id, 
-  :file     => File.open("~/image.png"), 
+  :post_id  => post.id,
+  :file     => File.open("~/image.png"),
   :filename => "image.png"
 })
 

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -23,6 +23,9 @@ Commands:
   replace theme       Replaces the theme on Siteleaf entirely by the one in current local dir.
   replace theme -n    Replaces the theme on Siteleaf entirely by the one in current local dir without any prompts for user.
 
+  add theme           Adding an extra file to theme without changing the original theme but in case of name conflict it will replace.
+  add theme -n        Adding an extra file to theme without changing the original theme but in case of name conflict it will replace without any prompts for user.
+
   help                Prints this help document
   version             Prints the siteleaf gem version
 
@@ -172,6 +175,7 @@ def delete_theme_assets(site_id, prompts)
   ignore_paths = ['config.ru', '.*']
 
   if prompts
+    print 'Sure You want to delete theme?'
     print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
   else
     prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
@@ -183,6 +187,45 @@ def delete_theme_assets(site_id, prompts)
     end
     puts "=> #{missing_assets.size} asset(s) deleted.\n"
   end
+end
+
+
+def put_theme_assets(site_id, prompts)
+  theme = Siteleaf::Theme.find_by_site_id(site_id)
+  assets = theme.assets
+  updated_count = 0
+  prompted_by_user = 'n'
+  ignore_paths = ['config.ru', '.*']
+  ignore_paths += File.read('.siteleafignore').split(/\r?\n/) if File.exists?('.siteleafignore')
+
+  # upload files
+  paths = Dir.glob("**/*")
+  paths.each do |path|
+    if !File.directory?(path) && !ignore_paths.any?{|i| File.fnmatch?(i, path, File::FNM_CASEFOLD) || File.fnmatch?(i, File.basename(path), File::FNM_CASEFOLD) }
+      asset = assets.find{|a| a.filename == path }
+      if asset.nil? || (asset && asset.checksum != Digest::MD5.hexdigest(File.read(path)))
+        print "Uploading #{path}..."
+        if prompts
+          print 'Sure You want to replace this file?'
+          print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
+        else
+          prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
+        end
+        if !prompts || || prompted_by_user == 'y'
+          asset.delete if asset
+          next
+        end
+        if response = Siteleaf::Asset.create({:site_id => site_id, :theme_id => theme.id, :file => File.new(path), :filename => path})
+          updated_count += 1
+          print "complete.\n"
+        else
+          print "error.\n"
+          break
+        end
+      end
+    end
+  end
+  print "=> #{updated_count} asset(s) uploaded."
 end
 
 
@@ -277,6 +320,23 @@ when 'replace'  # replacement of entire theme with the new one no old files or f
         else
           delete_theme_assets(site_id,true) # true is for prompts on cmd for user
           put_theme_assets(site_id,false)
+        end
+      else
+        puts "Site not configured, run `siteleaf config yoursite.com`.\n"
+      end
+    end
+  else
+    puts "`#{ARGV[0]}` command not found.\n"
+  end
+when 'add'  # add a file to theme
+  case ARGV[1]
+  when 'theme'
+    if auth != false
+      if site_id = get_site_id
+        if ARGV[2] ==  '-n'     # -n is for no prompt notifications
+          add_theme(site_id,false) # false is for no prompts on cmd for user
+        else
+          add_theme(site_id,true) # true is for prompts on cmd for user
         end
       else
         puts "Site not configured, run `siteleaf config yoursite.com`.\n"

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -334,9 +334,9 @@ when 'add'  # add a file to theme
     if auth != false
       if site_id = get_site_id
         if ARGV[2] ==  '-n'     # -n is for no prompt notifications
-          add_theme(site_id,false) # false is for no prompts on cmd for user
+          add_theme_assets(site_id,false) # false is for no prompts on cmd for user
         else
-          add_theme(site_id,true) # true is for prompts on cmd for user
+          add_theme_assets(site_id,true) # true is for prompts on cmd for user
         end
       else
         puts "Site not configured, run `siteleaf config yoursite.com`.\n"

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -190,7 +190,7 @@ def delete_theme_assets(site_id, prompts)
 end
 
 
-def put_theme_assets(site_id, prompts)
+def add_theme_assets(site_id, prompts)
   theme = Siteleaf::Theme.find_by_site_id(site_id)
   assets = theme.assets
   updated_count = 0
@@ -211,7 +211,7 @@ def put_theme_assets(site_id, prompts)
         else
           prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
         end
-        if !prompts || || prompted_by_user == 'y'
+        if !prompts || prompted_by_user == 'y'
           asset.delete if asset
           next
         end

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -152,7 +152,6 @@ def put_theme_assets(site_id, prompts)
     end
     if prompts
       print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
-    else
       prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
     end
     if !prompts || prompted_by_user == 'y' # could have shortened but wanted seperate line for $stdin
@@ -177,7 +176,6 @@ def delete_theme_assets(site_id, prompts)
   if prompts
     print 'Sure You want to delete theme?'
     print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
-  else
     prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
   end
   if !prompts || prompted_by_user == 'y'
@@ -185,7 +183,7 @@ def delete_theme_assets(site_id, prompts)
       print "Deleting #{asset.filename}..."
       asset.delete
     end
-    puts "=> #{missing_assets.size} asset(s) deleted.\n"
+    puts "=> asset(s) deleted.\n"
   end
 end
 
@@ -206,9 +204,8 @@ def add_theme_assets(site_id, prompts)
       if asset.nil? || (asset && asset.checksum != Digest::MD5.hexdigest(File.read(path)))
         print "Uploading #{path}..."
         if prompts
-          print 'Sure You want to replace this file?'
+          print 'Sure You want to replace this file?\n'
           print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
-        else
           prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
         end
         if !prompts || prompted_by_user == 'y'

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -14,8 +14,15 @@ Commands:
   s, server           Starts a local server.
   c, config DOMAIN    Configure an existing directory
   n, new DOMAIN       Creates new site on siteleaf.net
-  pull theme          Pulls theme files for configured site from Siteleaf
+  pull theme          Pulls theme files for configured site from Siteleaf.
   push theme          Pushes all files in dir as theme to configured site.
+
+  push theme -n       Pushes all files in dir as theme to configured site without any prompts for user.
+  delete theme        Deletes all files from Siteleaf (careful usage necessary).
+  delete theme -n     Deletes all files from Siteleaf (careful usage necessary) without any prompts for user.
+  replace theme       Replaces the theme on Siteleaf entirely by the one in current local dir.
+  replace theme -n    Replaces the theme on Siteleaf entirely by the one in current local dir without any prompts for user.
+
   help                Prints this help document
   version             Prints the siteleaf gem version
 
@@ -101,13 +108,14 @@ def get_theme_assets(site_id)
   end
 end
 
-def put_theme_assets(site_id)
+def put_theme_assets(site_id, prompts)
   theme = Siteleaf::Theme.find_by_site_id(site_id)
   assets = theme.assets
   updated_count = 0
+  prompted_by_user = 'n'
   ignore_paths = ['config.ru', '.*']
   ignore_paths += File.read('.siteleafignore').split(/\r?\n/) if File.exists?('.siteleafignore')
-  
+
   # upload files
   paths = Dir.glob("**/*")
   paths.each do |path|
@@ -126,10 +134,10 @@ def put_theme_assets(site_id)
       end
     end
   end
-  
+
   # check for old files
   missing_assets = []
-  assets.each do |asset| 
+  assets.each do |asset|
     missing_assets << asset if !paths.include?(asset.filename)
   end
   if missing_assets.empty?
@@ -139,8 +147,12 @@ def put_theme_assets(site_id)
     missing_assets.each do |asset|
       puts asset.filename
     end
-    print '(y/n)? '
-    if $stdin.gets.chomp == 'y'
+    if prompts
+      print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
+    else
+      prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
+    end
+    if !prompts || prompted_by_user == 'y' # could have shortened but wanted seperate line for $stdin
       missing_assets.each do |asset|
         print "Deleting #{asset.filename}..."
         asset.delete
@@ -150,6 +162,29 @@ def put_theme_assets(site_id)
     end
   end
 end
+
+
+def delete_theme_assets(site_id, prompts)
+  theme = Siteleaf::Theme.find_by_site_id(site_id)
+  assets = theme.assets
+  updated_count = 0
+  prompted_by_user = 'n'
+  ignore_paths = ['config.ru', '.*']
+
+  if prompts
+    print '(y/n)? '  # Will not print if prompts is false i.e user has entered -n
+  else
+    prompted_by_user = $stdin.gets.chomp  # Will only ask if prompts is true i.e user has not entered -n
+  end
+  if !prompts || prompted_by_user == 'y'
+    assets.each do |asset|
+      print "Deleting #{asset.filename}..."
+      asset.delete
+    end
+    puts "=> #{missing_assets.size} asset(s) deleted.\n"
+  end
+end
+
 
 case ARGV[0]
 when '-v', '--version', 'version'
@@ -202,7 +237,47 @@ when 'push'
   when 'theme'
     if auth != false
       if site_id = get_site_id
-        put_theme_assets(site_id)
+        if ARGV[2] ==  '-n'     # -n is for no prompt notifications
+          put_theme_assets(site_id,false) # false is for no prompts on cmd for user
+        else
+          put_theme_assets(site_id,true) # true is for prompts on cmd for user
+        end
+      else
+        puts "Site not configured, run `siteleaf config yoursite.com`.\n"
+      end
+    end
+  else
+    puts "`#{ARGV[0]}` command not found.\n"
+  end
+when 'delete'   # deletion of entire theme
+  case ARGV[1]
+  when 'theme'
+    if auth != false
+      if site_id = get_site_id
+        if ARGV[2] ==  '-n'     # -n is for no prompt notifications
+          delete_theme_assets(site_id,false) # false is for no prompts on cmd for user
+        else
+          delete_theme_assets(site_id,true) # true is for prompts on cmd for user
+        end
+      else
+        puts "Site not configured, run `siteleaf config yoursite.com`.\n"
+      end
+    end
+  else
+    puts "`#{ARGV[0]}` command not found.\n"
+  end
+when 'replace'  # replacement of entire theme with the new one no old files or folders will persist like they do in push
+  case ARGV[1]
+  when 'theme'
+    if auth != false
+      if site_id = get_site_id
+        if ARGV[2] ==  '-n'     # -n is for no prompt notifications
+          delete_theme_assets(site_id,false) # false is for no prompts on cmd for user
+          put_theme_assets(site_id,false)
+        else
+          delete_theme_assets(site_id,true) # true is for prompts on cmd for user
+          put_theme_assets(site_id,false)
+        end
       else
         puts "Site not configured, run `siteleaf config yoursite.com`.\n"
       end

--- a/bin/siteleaf
+++ b/bin/siteleaf
@@ -222,7 +222,7 @@ def add_theme_assets(site_id, prompts)
       end
     end
   end
-  print "=> #{updated_count} asset(s) uploaded."
+  print "=> #{updated_count} asset(s) uploaded.\n"
 end
 
 


### PR DESCRIPTION
1. ```siteleaf push theme -n```       Pushes all files in dir as theme to configured site without any prompts for user.

2. ```siteleaf delete theme ```        Deletes all files from Siteleaf (careful usage necessary).
  
3. ```siteleaf delete theme -n ```     Deletes all files from Siteleaf (careful usage necessary) without any prompts for user.
 
4. ```siteleaf replace theme```        Replaces the theme on Siteleaf entirely by the one in current local dir.

5. ```siteleaf replace theme -n ```    Replaces the theme on Siteleaf entirely by the one in current local dir without any prompts for user.

6. ```siteleaf add theme```           Adding an extra file to theme without changing the original theme but in case of name conflict it will replace.

7. ```siteleaf add theme -n```        Adding an extra file to theme without changing the original theme but in case of name conflict it will replace without any prompts for user.

Created an Issue https://github.com/siteleaf/siteleaf-gem/issues/34

