### PR TITLE
Include asset relationships in export

### DIFF
--- a/lib/siteleaf/asset.rb
+++ b/lib/siteleaf/asset.rb
@@ -1,9 +1,9 @@
 module Siteleaf
   class Asset < Entity
 
-    attr_accessor :file, :filename, :replace, :site_id, :page_id, :post_id, :theme_id
+    attr_accessor :file, :filename, :replace, :site_id, :page_id, :post_id, :theme_id, :meta
     attr_reader :id, :url, :content_type, :filesize, :checksum, :created_at, :updated_at
-    
+
     def create_endpoint
       if !self.post_id.nil?
         "posts/#{self.post_id}/assets"
@@ -15,22 +15,22 @@ module Siteleaf
         "sites/#{self.site_id}/assets"
       end
     end
-    
+
     def post
       Post.find(self.post_id) if self.post_id
     end
-    
+
     def page
       Page.find(self.page_id) if self.page_id
     end
-    
+
     def theme
       Theme.find(self.theme_id) if self.theme_id
     end
-    
+
     def site
       Site.find(self.site_id) if self.site_id
     end
-    
+
   end
 end

--- a/lib/siteleaf/page.rb
+++ b/lib/siteleaf/page.rb
@@ -52,8 +52,10 @@ module Siteleaf
       meta.each{|m| attrs[m['key'].to_s.downcase] = m['value'].to_s == '' ? nil : m['value'].to_s.gsub("\r\n","\n")} unless meta.nil?
 
       unless assets.to_a.empty?
-        attrs['assets'] = assets.map do |asset|
-          asset.filename
+        attrs['assets'] = assets.map do |a|
+          asset = {'path' => "/uploads/#{a.filename}"}
+          a.meta.each{|m| asset[m['key'].to_s.downcase] = m['value'].to_s == '' ? nil : m['value'].to_s.gsub("\r\n","\n")} unless meta.nil?
+          asset
         end
       end
 

--- a/lib/siteleaf/version.rb
+++ b/lib/siteleaf/version.rb
@@ -1,3 +1,3 @@
 module Siteleaf
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end


### PR DESCRIPTION
I added this for my own site so a couple things that we maybe want to change:

- This only includes the filename (no directory). I preferred it without, making switching from assets to uploads (or changing in the future) slightly less tedious.
- No metadata, I wasn't using it. ¯\\\_(ツ)_/¯ 

~~~yaml
assets:
- img-01.jpg
- img-02.jpg
~~~